### PR TITLE
Increment version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-xml-lite",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pure javascript XML ANSI/Unicode SAX parser for Node.js",
   "keywords": [
     "xml",


### PR DESCRIPTION
We needed to update the version number in order to force an update for some of our libraries in order to take the fix for Issue #3 (thanks for that by the way!). We're contributing it back in case it's of use to other clients.
