### PR TITLE
fix issue #10

### DIFF
--- a/index.js
+++ b/index.js
@@ -518,6 +518,8 @@ XMLParser.prototype.parseBuffer = function(buffer, len, event) {
                 switch (this.position) {
                     case 0:
                         if (c != CHAR_MINU) {
+                            this.str.append(CHAR_MINU);
+                            this.str.append(c);
                             this.position = 2;
                             this.stack.state = xsElementComment;
                         } else {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const
     xsElementDataPI = 17,
     xsCloseElementPI = 18,
     xsElementCDATA = 19,
-    xsClodeElementCDATA = 20,
+    xsCloseElementCDATA = 20,
     xsEscape = 21,
     xsEscape_lt = 22,
     xsEscape_gt = 23,
@@ -599,13 +599,13 @@ XMLParser.prototype.parseBuffer = function(buffer, len, event) {
                     default:
                         if (c == CHAR_RIBR) {
                             this.position = 0;
-                            this.stack.state = xsClodeElementCDATA;
+                            this.stack.state = xsCloseElementCDATA;
                         } else {
                             this.value.append(c);
                         }
                 }
                 break;
-            case xsClodeElementCDATA:
+            case xsCloseElementCDATA:
                 switch (this.position) {
                     case 0:
                         if (c == CHAR_RIBR) {

--- a/test/test.xml
+++ b/test/test.xml
@@ -4,6 +4,7 @@
     <!-- text-->
     truc
     <!-- comment -->
+    <!-- comment-with-hyphen -->
     foo
     &amp;&lt;&gt;&quot;
     <node:x>foo</node:x>


### PR DESCRIPTION
quick fix to problem outlined in issue #10 

the issue is, when parsing a comment in the `XMLParser`, if the code encounter a `-` character, it will not append it to `this.str` property before it switch to the `xsCloseElementComment` state. If subsequent charater is not `-`, it will skip the character, go back to the `xsElementComment` state and continue parsing. When this happens the `-` character and subsequent character is never appended to `this.str` hence missed in the output string.

My fix is to append `-` character and subsequent character back to `this.str` when this happens. 

This fix won't fix the case when a comment have more than 1 `-` character in the middle. e.g. when you parse `<!-- multiple--hyphen -->` it will cause a parsing error, but this is correct according to the xml specification https://www.w3.org/TR/REC-xml/#sec-comments

>  For compatibility, the string " -- " (double-hyphen) MUST NOT occur within comments.
